### PR TITLE
Add precision override helper and update benchmarks/tests

### DIFF
--- a/tests/bench.py
+++ b/tests/bench.py
@@ -163,9 +163,7 @@ def _wrap_model_with_dpcs(model: nn.Module, device: str, cfg: BenchConfig) -> DP
                 allow_fp8=cfg.allow_fp8)
     model = dpcs.wrap(model)
     if not cfg.enable_precision:
-        # force all modes to fp32 if precision policy is disabled
-        for st in dpcs._registry.values():
-            st.mode = "fp32"
+        dpcs.force_fp32()
     # set ckpt policy
     dpcs._ckpt_on = bool(cfg.enable_ckpt)
     return dpcs

--- a/tests/test_checkpointing_regression.py
+++ b/tests/test_checkpointing_regression.py
@@ -36,8 +36,7 @@ def _clone_with_same_weights(model: nn.Module) -> nn.Module:
 
 
 def _force_fp32_modes(sched: DPCS):
-    for st in sched._registry.values():
-        st.mode = "fp32"
+    sched.force_fp32()
 
 
 @pytest.mark.parametrize("device", ["cpu"])  # CUDA memory test is separate

--- a/tests/test_checkpointing_regression_single_model.py
+++ b/tests/test_checkpointing_regression_single_model.py
@@ -28,8 +28,7 @@ class DeepMLP(nn.Module):
 
 
 def _force_fp32_modes(sched: DPCS):
-    for st in sched._registry.values():
-        st.mode = "fp32"
+    sched.force_fp32()
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required for memory regression check")

--- a/tests/test_checkpointing_transformer.py
+++ b/tests/test_checkpointing_transformer.py
@@ -46,8 +46,7 @@ class TinyTransformer(nn.Module):
 
 def _force_fp32_modes(sched: DPCS):
     # helper to keep numerics comparable
-    for st in sched._registry.values():
-        st.mode = "fp32"
+    sched.force_fp32()
 
 
 @pytest.mark.parametrize("device", ["cpu"])  # numerical parity on CPU


### PR DESCRIPTION
## Summary
- add a precision-override compatibility layer in the scheduler, including a `_LeafState` registry facade and manual FP32 forcing helpers
- extend `GradSignals` with last-variance tracking so the compatibility facade can expose gradient stats
- update the benchmarks and checkpointing tests to use `force_fp32()` instead of mutating `_registry` entries directly

## Testing
- PYTHONPATH=src pytest tests/test_checkpointing_regression.py::test_checkpointing_equivalence_numeric_cpu -q
- PYTHONPATH=src pytest tests/test_checkpointing_transformer.py::test_checkpointing_equivalence_numeric_cpu_transformer -q
- PYTHONPATH=src python tests/bench.py --model transformer --device cpu --steps 1 --batch 1
- PYTHONPATH=src python tests/bench.py --model transformer --device cuda --steps 1 --batch 1  # fails: no NVIDIA GPU in container


------
https://chatgpt.com/codex/tasks/task_e_68cc7cf766e48322abb7602c5ebbe503