### PR TITLE
Add FP8 support to precision policy

### DIFF
--- a/src/dpcs/__init__.py
+++ b/src/dpcs/__init__.py
@@ -6,6 +6,7 @@ Usage:
 from __future__ import annotations
 
 from .scheduler import DPCS          # orchestrator
-from .config import DPCSConfig, CheckpointCfg  # frozen configs
+from .config import DPCSConfig, CheckpointCfg
+from .policies import PrecisionCfg
 
-__all__ = ["DPCS", "DPCSConfig", "CheckpointCfg"]
+__all__ = ["DPCS", "DPCSConfig", "CheckpointCfg", "PrecisionCfg"]


### PR DESCRIPTION
## Summary
- extend PrecisionPolicy with FP8 gating, re-entry cooldowns, and runtime-configurable headroom thresholds
- propagate headroom thresholds from the scheduler when enabling TransformerEngine modules
- expose PrecisionCfg in the public package surface and make the state registry iterate over original modules for easier inspection

## Testing
- PYTHONPATH=src pytest *(fails: stats autotune expectations do not hold in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccfa21ce1c83228329731b272e1617