### PR TITLE
Force bf16 precision for bench baseline runs

### DIFF
--- a/tests/bench.py
+++ b/tests/bench.py
@@ -163,7 +163,10 @@ def _wrap_model_with_dpcs(model: nn.Module, device: str, cfg: BenchConfig) -> DP
                 allow_fp8=cfg.allow_fp8)
     model = dpcs.wrap(model)
     if not cfg.enable_precision:
-        dpcs.force_fp32()
+        if device == "cuda" and torch.cuda.is_available() and torch.cuda.is_bf16_supported():
+            dpcs.force_precision("bf16")
+        else:
+            dpcs.force_fp32()
     # set ckpt policy
     dpcs._ckpt_on = bool(cfg.enable_ckpt)
     return dpcs


### PR DESCRIPTION
## Summary
- force bf16 precision for CUDA baseline runs in the bench harness when bf16 is supported
- keep the previous fp32 fallback for other devices

## Testing
- pytest tests/test_precision_scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1772e0c88322bda912fc32ee0d8b