### PR TITLE
Force fp16 precision for CUDA baseline runs

### DIFF
--- a/tests/bench.py
+++ b/tests/bench.py
@@ -163,7 +163,10 @@ def _wrap_model_with_dpcs(model: nn.Module, device: str, cfg: BenchConfig) -> DP
                 allow_fp8=cfg.allow_fp8)
     model = dpcs.wrap(model)
     if not cfg.enable_precision:
-        dpcs.force_fp32()
+        if device == "cuda" and torch.cuda.is_available():
+            dpcs.force_precision("fp16")
+        else:
+            dpcs.force_fp32()
     # set ckpt policy
     dpcs._ckpt_on = bool(cfg.enable_ckpt)
     return dpcs


### PR DESCRIPTION
## Summary
- switch the bench baseline override to force fp16 on CUDA devices
- keep the fp32 fallback for non-CUDA baseline runs

## Testing
- pytest tests/test_precision_scheduler.py


------
https://chatgpt.com/codex/tasks/task_e_68cd1772e0c88322bda912fc32ee0d8b